### PR TITLE
Add support for `Path` in `ZipPackage` and for image modification in HSSF

### DIFF
--- a/poi-ooxml/build.gradle
+++ b/poi-ooxml/build.gradle
@@ -290,9 +290,7 @@ javadoc {
     failOnError = true
     doFirst {
         options {
-            if (JavaVersion.current().isJava9Compatible()) {
-                addBooleanOption('html5', true)
-            }
+            if (jdkVersion > 8) addBooleanOption('html5', true)
             links 'https://poi.apache.org/apidocs/dev/'
             links 'https://docs.oracle.com/javase/8/docs/api/'
             use = true

--- a/poi-ooxml/src/main/java/org/apache/poi/openxml4j/opc/OPCPackage.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/openxml4j/opc/OPCPackage.java
@@ -301,7 +301,7 @@ public abstract class OPCPackage implements RelationshipSource, Closeable {
            if (pack.partList == null && access != PackageAccess.WRITE) {
                pack.getParts();
            }
-           pack.originalPackagePath = path;
+           pack.originalPackagePath = path.toAbsolutePath();
            return pack;
        } catch (InvalidFormatException | RuntimeException e) {
            if (access == PackageAccess.READ) {
@@ -390,7 +390,7 @@ public abstract class OPCPackage implements RelationshipSource, Closeable {
 
         // Creates a new package
         OPCPackage pkg = new ZipPackage();
-        pkg.originalPackagePath = file.toPath();
+        pkg.originalPackagePath = file.getAbsoluteFile().toPath();
 
         configurePackage(pkg);
         return pkg;
@@ -1494,7 +1494,7 @@ public abstract class OPCPackage implements RelationshipSource, Closeable {
         this.throwExceptionIfReadOnly();
 
         // You shouldn't save the same file, do a close instead
-        if(Files.exists(targetPath) && Files.isSameFile(targetPath, originalPackagePath)) {
+        if (Files.exists(targetPath) && Files.isSameFile(targetPath.toAbsolutePath(), originalPackagePath)) {
             throw new InvalidOperationException(
                     "You can't call save(File) to save to the currently open " +
                     "file. To save to the current file, please just call close()"

--- a/poi-ooxml/src/main/java/org/apache/poi/openxml4j/opc/OPCPackage.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/openxml4j/opc/OPCPackage.java
@@ -285,7 +285,7 @@ public abstract class OPCPackage implements RelationshipSource, Closeable {
      * @param path
      *            The path of the file to open.
      * @param access
-     *            Type of access to the file that is allowed/
+     *            Type of access to the file that is allowed
      * @return A PackageBase object, else <b>null</b>.
      * @throws InvalidFormatException
      *             If the specified file doesn't exist, and a parsing error

--- a/poi-ooxml/src/main/java/org/apache/poi/openxml4j/opc/OPCPackage.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/openxml4j/opc/OPCPackage.java
@@ -260,7 +260,7 @@ public abstract class OPCPackage implements RelationshipSource, Closeable {
             }
         }
 
-        pack.originalPackagePath = Paths.get(path);
+        pack.originalPackagePath = Paths.get(path).toAbsolutePath();
         return pack;
     }
 

--- a/poi-ooxml/src/main/java/org/apache/poi/openxml4j/opc/internal/ZipHelper.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/openxml4j/opc/internal/ZipHelper.java
@@ -18,12 +18,13 @@
 package org.apache.poi.openxml4j.opc.internal;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
 import org.apache.commons.compress.archivers.zip.ZipArchiveInputStream;
@@ -179,33 +180,6 @@ public final class ZipHelper {
     }
 
     /**
-     * Opens the specified file as a secure zip, or returns null if no 
-     *  such file exists
-     *
-     * @param file
-     *            The file to open.
-     * @return The zip archive freshly open.
-     * @throws IOException if the zip file cannot be opened or closed to read the header signature
-     * @throws NotOfficeXmlFileException if stream does not start with zip header signature
-     */
-    public static ZipSecureFile openZipFile(File file) throws IOException, NotOfficeXmlFileException {
-        if (!file.exists()) {
-            throw new FileNotFoundException("File does not exist");
-        }
-        if (file.isDirectory()) {
-            throw new IOException("File is a directory");
-        }
-        
-        // Peek at the first few bytes to sanity check
-        try (FileInputStream input = new FileInputStream(file)) {
-            verifyZipHeader(input);
-        }
-
-        // Open as a proper zip file
-        return new ZipSecureFile(file);
-    }
-
-    /**
      * Retrieve and open as a secure zip file with the specified path.
      *
      * @param path
@@ -214,5 +188,43 @@ public final class ZipHelper {
      */
     public static ZipSecureFile openZipFile(String path) throws IOException {
         return openZipFile(new File(path));
+    }
+
+
+    /**
+     * Retrieve and open as a secure zip file with the specified file.
+     *
+     * @param file
+     *            The file to open.
+     * @return The zip archive freshly open.
+     */
+    public static ZipSecureFile openZipFile(File file) throws IOException, NotOfficeXmlFileException {
+        return openZipFile(file.toPath());
+    }
+
+    /**
+     * Retrieve and open as a secure zip file with the specified path.
+     *
+     * @param path
+     *            The file to open.
+     * @return The zip archive freshly open.
+     * @throws IOException if the zip file cannot be opened or closed to read the header signature
+     * @throws NotOfficeXmlFileException if stream does not start with zip header signature
+     */
+    public static ZipSecureFile openZipFile(Path path) throws IOException, NotOfficeXmlFileException {
+        if (!Files.exists(path)) {
+            throw new FileNotFoundException("File does not exist");
+        }
+        if (Files.isDirectory(path)) {
+            throw new IOException("File is a directory");
+        }
+
+        // Peek at the first few bytes to sanity check
+        try (InputStream input = Files.newInputStream(path)) {
+            verifyZipHeader(input);
+        }
+
+        // Open as a proper zip file
+        return new ZipSecureFile(path);
     }
 }

--- a/poi-ooxml/src/main/java/org/apache/poi/openxml4j/util/ZipSecureFile.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/openxml4j/util/ZipSecureFile.java
@@ -19,8 +19,14 @@ package org.apache.poi.openxml4j.util;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.EnumSet;
 
 import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
+import org.apache.commons.compress.archivers.zip.ZipEncodingHelper;
 import org.apache.commons.compress.archivers.zip.ZipFile;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -129,13 +135,22 @@ public class ZipSecureFile extends ZipFile {
     }
 
     public ZipSecureFile(File file) throws IOException {
-        super(file);
-        this.fileName = file.getAbsolutePath();
+        this(file.toPath());
+    }
+
+    public ZipSecureFile(Path path) throws IOException {
+        super(
+            Files.newByteChannel(path, EnumSet.of(StandardOpenOption.READ)),
+            path.toAbsolutePath().toString(),
+            StandardCharsets.UTF_8.name(),
+            true,
+            false
+        );
+        this.fileName = path.toAbsolutePath().toString();
     }
 
     public ZipSecureFile(String name) throws IOException {
-        super(name);
-        this.fileName = new File(name).getAbsolutePath();
+        this(new File(name));
     }
 
     /**

--- a/poi-ooxml/src/main/java/org/apache/poi/openxml4j/util/ZipSecureFile.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/openxml4j/util/ZipSecureFile.java
@@ -22,11 +22,11 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.util.EnumSet;
 
 import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
-import org.apache.commons.compress.archivers.zip.ZipEncodingHelper;
 import org.apache.commons.compress.archivers.zip.ZipFile;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -150,7 +150,7 @@ public class ZipSecureFile extends ZipFile {
     }
 
     public ZipSecureFile(String name) throws IOException {
-        this(new File(name));
+        this(Paths.get(name));
     }
 
     /**
@@ -167,7 +167,6 @@ public class ZipSecureFile extends ZipFile {
      * @throws IllegalStateException if the zip file has been closed
      */
     @Override
-    @SuppressWarnings("resource")
     public ZipArchiveThresholdInputStream getInputStream(ZipArchiveEntry entry) throws IOException {
         ZipArchiveThresholdInputStream zatis = new ZipArchiveThresholdInputStream(super.getInputStream(entry));
         zatis.setEntry(entry);

--- a/poi-scratchpad/src/main/java/org/apache/poi/hsmf/datatypes/StoragePropertiesChunk.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hsmf/datatypes/StoragePropertiesChunk.java
@@ -54,7 +54,7 @@ public class StoragePropertiesChunk extends PropertiesChunk {
      * Writes out pre-calculated header values which assume any variable length property `data`
      *  field to already have Size and Reserved
      * @param out output stream (calling code must close this stream)
-     * @throws IOException
+     * @throws IOException if any I/O exception occurs.
      */
     public void writePreCalculatedValue(OutputStream out) throws IOException {
         // 8 bytes of reserved zeros

--- a/poi/src/main/java/org/apache/poi/ddf/EscherBitmapBlip.java
+++ b/poi/src/main/java/org/apache/poi/ddf/EscherBitmapBlip.java
@@ -121,6 +121,11 @@ public class EscherBitmapBlip extends EscherBlipRecord {
     }
 
     @Override
+    public void setUIDs(byte[] uid) {
+        setUID(uid);
+    }
+
+    @Override
     public Map<String, Supplier<?>> getGenericProperties() {
         return GenericRecordUtil.getGenericProperties(
             "base", super::getGenericProperties,

--- a/poi/src/main/java/org/apache/poi/ddf/EscherBlipRecord.java
+++ b/poi/src/main/java/org/apache/poi/ddf/EscherBlipRecord.java
@@ -124,6 +124,15 @@ public class EscherBlipRecord extends EscherRecord {
         field_pictureData = IOUtils.safelyClone(pictureData, offset, length, MAX_RECORD_LENGTH);
     }
 
+    /**
+     * Sets all UIDs for the record.
+     *
+     * @param uid MD4 message digest of the image data.
+     */
+    public void setUIDs(byte[] uid) {
+        // No-op - not abstract so as not to break app developers who have subclassed.
+    }
+
     @Override
     public Map<String, Supplier<?>> getGenericProperties() {
         return GenericRecordUtil.getGenericProperties(

--- a/poi/src/main/java/org/apache/poi/ddf/EscherMetafileBlip.java
+++ b/poi/src/main/java/org/apache/poi/ddf/EscherMetafileBlip.java
@@ -73,7 +73,7 @@ public final class EscherMetafileBlip extends EscherBlipRecord {
     private int field_4_ptSize_h;
     private int field_5_cbSave;
     private byte field_6_fCompression;
-    private byte field_7_fFilter;
+    private byte field_7_fFilter = (byte) 0xFE;
 
     private byte[] raw_pictureData;
     private byte[] remainingData;
@@ -421,6 +421,12 @@ public final class EscherMetafileBlip extends EscherBlipRecord {
 
         setCompressedSize(raw_pictureData.length);
         setCompressed(true);
+    }
+
+    @Override
+    public void setUIDs(byte[] uid) {
+        setUID(uid);
+        setPrimaryUID(uid);
     }
 
     @Override

--- a/poi/src/main/java/org/apache/poi/hssf/model/DrawingManager2.java
+++ b/poi/src/main/java/org/apache/poi/hssf/model/DrawingManager2.java
@@ -19,21 +19,156 @@ package org.apache.poi.hssf.model;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.poi.ddf.EscherBSERecord;
+import org.apache.poi.ddf.EscherBitmapBlip;
+import org.apache.poi.ddf.EscherBlipRecord;
+import org.apache.poi.ddf.EscherBoolProperty;
+import org.apache.poi.ddf.EscherContainerRecord;
 import org.apache.poi.ddf.EscherDgRecord;
 import org.apache.poi.ddf.EscherDggRecord;
+import org.apache.poi.ddf.EscherMetafileBlip;
+import org.apache.poi.ddf.EscherOptRecord;
+import org.apache.poi.ddf.EscherPropertyTypes;
+import org.apache.poi.ddf.EscherRGBProperty;
+import org.apache.poi.ddf.EscherRecord;
+import org.apache.poi.ddf.EscherRecordTypes;
+import org.apache.poi.ddf.EscherSplitMenuColorsRecord;
+import org.apache.poi.hssf.record.CountryRecord;
+import org.apache.poi.hssf.record.DrawingGroupRecord;
+import org.apache.poi.hssf.usermodel.HSSFPictureData;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.util.Internal;
+import org.apache.poi.util.Removal;
+
+import static org.apache.poi.ss.usermodel.Workbook.PICTURE_TYPE_DIB;
+import static org.apache.poi.ss.usermodel.Workbook.PICTURE_TYPE_EMF;
+import static org.apache.poi.ss.usermodel.Workbook.PICTURE_TYPE_JPEG;
+import static org.apache.poi.ss.usermodel.Workbook.PICTURE_TYPE_PICT;
+import static org.apache.poi.ss.usermodel.Workbook.PICTURE_TYPE_PNG;
+import static org.apache.poi.ss.usermodel.Workbook.PICTURE_TYPE_WMF;
 
 
 /**
  * Provides utilities to manage drawing groups.
  */
 public class DrawingManager2 {
+    private static final Logger LOGGER = LogManager.getLogger(DrawingManager2.class);
     private final EscherDggRecord dgg;
+
+    /**
+     * A {@link EscherRecordTypes#BSTORE_CONTAINER}.
+     */
+    private final EscherContainerRecord bStoreContainer;
     private final List<EscherDgRecord> drawingGroups = new ArrayList<>();
 
-
+    /**
+     * @deprecated This class is intended to be internal to POI. To get instances of it, call
+     * {@link InternalWorkbook#getDrawingManager()}.
+     */
+    @Deprecated
+    @Removal(version = "5.4")
     public DrawingManager2( EscherDggRecord dgg ) {
-        this.dgg = dgg;
+        this(dgg, new EscherContainerRecord());
+        LOGGER.atWarn().log("Detached BStore container created = data won't be saved.");
+        bStoreContainer.setRecordId(EscherContainerRecord.BSTORE_CONTAINER);
+    }
+
+    private DrawingManager2(EscherDggRecord dgg, EscherContainerRecord bStoreContainer) {
+        this.dgg = Objects.requireNonNull(dgg);
+        this.bStoreContainer = Objects.requireNonNull(bStoreContainer);
+    }
+
+    /**
+     * Initializes a {@link DrawingManager2} tied to the given workbook.
+     * <p>
+     * If the workbook does not yet have records for the Drawing Group, BStore, & DGG records, new records will be
+     * created and added to the workbook.
+     *
+     * @param workbook From which to initialize the {@link DrawingManager2}.
+     * @return The new {@link DrawingManager2} instance.
+     */
+    static synchronized DrawingManager2 forWorkbook(InternalWorkbook workbook) {
+        DrawingGroupRecord drawingGroup = (DrawingGroupRecord) workbook.findFirstRecordBySid(DrawingGroupRecord.sid);
+
+        if (drawingGroup != null) {
+            drawingGroup.decode();
+        } else {
+            drawingGroup = createDrawingGroupRecord();
+
+            int index = workbook.findFirstRecordLocBySid(CountryRecord.sid);
+            workbook.getWorkbookRecordList().add(index + 1, drawingGroup);
+        }
+
+        EscherContainerRecord dggContainer = drawingGroup.getEscherContainer();
+
+        EscherDggRecord dggRecord = dggContainer.getChildById(EscherDggRecord.RECORD_ID);
+        if (dggRecord == null) {
+            dggRecord = createEscherDggRecord();
+            dggContainer.addChildRecord(dggRecord);
+        }
+
+        EscherContainerRecord bStoreContainer = dggContainer.getChildById(EscherContainerRecord.BSTORE_CONTAINER);
+        if (bStoreContainer == null) {
+            // Create an empty store and use that. An empty store doesn't cause any problems, but makes the programmatic
+            //  model easier to understand.
+            bStoreContainer = new EscherContainerRecord();
+            bStoreContainer.setRecordId(EscherContainerRecord.BSTORE_CONTAINER);
+            bStoreContainer.setOptions((short) (0xF));
+
+            List<EscherRecord> childRecords = dggContainer.getChildRecords();
+            childRecords.add(1, bStoreContainer);
+            dggContainer.setChildRecords(childRecords);
+        }
+
+        return new DrawingManager2(dggRecord, bStoreContainer);
+    }
+
+    /**
+     * Creates a primary drawing group record.
+     */
+    private static DrawingGroupRecord createDrawingGroupRecord() {
+        EscherContainerRecord dggContainer = new EscherContainerRecord();
+        EscherDggRecord dgg = createEscherDggRecord();
+        EscherOptRecord opt = new EscherOptRecord();
+        EscherSplitMenuColorsRecord splitMenuColors = new EscherSplitMenuColorsRecord();
+
+        dggContainer.setRecordId(EscherContainerRecord.DGG_CONTAINER);
+        dggContainer.setOptions(EscherContainerRecord.DGG_CONTAINER);
+
+        EscherContainerRecord bStoreContainer = new EscherContainerRecord();
+        bStoreContainer.setRecordId(EscherContainerRecord.BSTORE_CONTAINER);
+        bStoreContainer.setOptions((short) (0xF));
+
+        opt.setRecordId(EscherOptRecord.RECORD_ID);
+        opt.addEscherProperty(new EscherBoolProperty(EscherPropertyTypes.TEXT__SIZE_TEXT_TO_FIT_SHAPE, 524296));
+        opt.addEscherProperty(new EscherRGBProperty(EscherPropertyTypes.FILL__FILLCOLOR, 0x08000041));
+        opt.addEscherProperty(new EscherRGBProperty(EscherPropertyTypes.LINESTYLE__COLOR, 134217792));
+        splitMenuColors.setRecordId(EscherSplitMenuColorsRecord.RECORD_ID);
+        splitMenuColors.setOptions((short) 0x0040);
+        splitMenuColors.setColor1(0x0800000D);
+        splitMenuColors.setColor2(0x0800000C);
+        splitMenuColors.setColor3(0x08000017);
+        splitMenuColors.setColor4(0x100000F7);
+
+        dggContainer.addChildRecord(dgg);
+        dggContainer.addChildRecord(bStoreContainer);
+        dggContainer.addChildRecord(opt);
+        dggContainer.addChildRecord(splitMenuColors);
+
+        DrawingGroupRecord drawingGroup = new DrawingGroupRecord();
+        drawingGroup.addEscherRecord(dggContainer);
+        return drawingGroup;
+    }
+
+    private static EscherDggRecord createEscherDggRecord() {
+        EscherDggRecord dgg = new EscherDggRecord();
+        dgg.setRecordId(EscherDggRecord.RECORD_ID);
+        dgg.setShapeIdMax(1024);
+        return dgg;
     }
     
     /**
@@ -95,5 +230,120 @@ public class DrawingManager2 {
      */
     public void incrementDrawingsSaved(){
         dgg.setDrawingsSaved(dgg.getDrawingsSaved()+1);
+    }
+
+    /**
+     * Gets the record at the given 1-based index.
+     * @param index 1-based index of the picture.
+     * @return Record at the given index.
+     * @throws IndexOutOfBoundsException if the index is larger than the number of available records.
+     */
+    EscherBSERecord getBSERecord(int index) {
+        return (EscherBSERecord) bStoreContainer.getChild(index - 1);
+    }
+
+    /**
+     * Allocates a new, empty picture in the workbook.
+     * <p>
+     * A picture is allocated by adding a {@link EscherBSERecord} for the picture to the workbook. The caller must
+     * provide the picture data via {@link HSSFPictureData#setData(byte[])}.
+     *
+     * @param format One of the image format constants {@link Workbook#PICTURE_TYPE_EMF},
+     *               {@link Workbook#PICTURE_TYPE_WMF}, {@link Workbook#PICTURE_TYPE_PICT},
+     *               {@link Workbook#PICTURE_TYPE_JPEG}, {@link Workbook#PICTURE_TYPE_PNG}, or
+     *               {@link Workbook#PICTURE_TYPE_DIB}.
+     * @return Newly allocated picture without any image data.
+     */
+    @Internal
+    public HSSFPictureData allocatePicture(int format) {
+        EscherBlipRecord blipRecord;
+        short escherTag;
+
+        if (format == PICTURE_TYPE_EMF || format == PICTURE_TYPE_WMF) {
+            blipRecord = new EscherMetafileBlip();
+            escherTag = 0;
+        } else {
+            blipRecord = new EscherBitmapBlip();
+            escherTag = (short) 0xFF;
+        }
+
+        blipRecord.setRecordId((short) (EscherBlipRecord.RECORD_ID_START + format));
+        switch (format) {
+            case PICTURE_TYPE_EMF:
+                blipRecord.setOptions(HSSFPictureData.MSOBI_EMF);
+                break;
+            case PICTURE_TYPE_WMF:
+                blipRecord.setOptions(HSSFPictureData.MSOBI_WMF);
+                break;
+            case PICTURE_TYPE_PICT:
+                blipRecord.setOptions(HSSFPictureData.MSOBI_PICT);
+                break;
+            case PICTURE_TYPE_PNG:
+                blipRecord.setOptions(HSSFPictureData.MSOBI_PNG);
+                break;
+            case PICTURE_TYPE_JPEG:
+                blipRecord.setOptions(HSSFPictureData.MSOBI_JPEG);
+                break;
+            case PICTURE_TYPE_DIB:
+                blipRecord.setOptions(HSSFPictureData.MSOBI_DIB);
+                break;
+            default:
+                throw new IllegalStateException("Unexpected picture format: " + format);
+        }
+
+        EscherBSERecord r = new EscherBSERecord();
+        r.setOptions((short) (0x0002 | (format << 4)));
+        r.setBlipTypeMacOS((byte) format);
+        r.setBlipTypeWin32((byte) format);
+        r.setTag(escherTag);
+        r.setBlipRecord(blipRecord);
+
+        addBSERecord(r);
+        return new HSSFPictureData(r);
+    }
+
+    /**
+     * Returns the pictures in the workbook associated with this {@link DrawingManager2}.
+     * <p>
+     * The pictures are ordered as they are stored in the worksheet.
+     *
+     * @return Pictures in the workbook.
+     */
+    @Internal
+    public List<HSSFPictureData> getAllPictures() {
+        ArrayList<HSSFPictureData> pictures = new ArrayList<>(bStoreContainer.getChildCount());
+        for (EscherRecord record : bStoreContainer) {
+            EscherBSERecord bse = (EscherBSERecord) record;
+
+            // We sometimes encounter sheets that have invalid BSE records
+            EscherBlipRecord blip = bse.getBlipRecord();
+            if (blip != null) {
+                pictures.add(new HSSFPictureData(bse));
+            } else {
+                LOGGER.atDebug().log("Encountered BSE record without a BLIP. BSE records must have a BLIP according to the specification.");
+            }
+        }
+        return pictures;
+    }
+
+    /**
+     * Returns the number of pictures in the workbook associated with this {@link DrawingManager2}.
+     *
+     * @return Number of pictures in the workbook.
+     */
+    @Internal
+    public int getPictureCount() {
+        return bStoreContainer.getChildCount();
+    }
+
+    /**
+     * Appends the given record to the {@link #bStoreContainer}.
+     */
+    private void addBSERecord(EscherBSERecord bse) {
+        Objects.requireNonNull(bse);
+        assert bse.getBlipRecord() != null;
+        int index = bStoreContainer.getChildCount() + 1;
+        bStoreContainer.setOptions((short) ((index << 4) | 0xF));
+        bStoreContainer.addChildRecord(bse);
     }
 }

--- a/poi/src/main/java/org/apache/poi/hssf/usermodel/HSSFPicture.java
+++ b/poi/src/main/java/org/apache/poi/hssf/usermodel/HSSFPicture.java
@@ -22,7 +22,6 @@ import java.awt.Dimension;
 import org.apache.commons.io.input.UnsynchronizedByteArrayInputStream;
 import org.apache.poi.ddf.DefaultEscherRecordFactory;
 import org.apache.poi.ddf.EscherBSERecord;
-import org.apache.poi.ddf.EscherBlipRecord;
 import org.apache.poi.ddf.EscherClientDataRecord;
 import org.apache.poi.ddf.EscherComplexProperty;
 import org.apache.poi.ddf.EscherContainerRecord;
@@ -218,8 +217,7 @@ public class HSSFPicture extends HSSFSimpleShape implements Picture {
 
         InternalWorkbook iwb = patriarch.getSheet().getWorkbook().getWorkbook();
         EscherBSERecord bse = iwb.getBSERecord(picIdx);
-        EscherBlipRecord blipRecord = bse.getBlipRecord();
-        return new HSSFPictureData(blipRecord);
+        return new HSSFPictureData(bse);
     }
 
     @Override

--- a/poi/src/main/java/org/apache/poi/hssf/usermodel/HSSFSheet.java
+++ b/poi/src/main/java/org/apache/poi/hssf/usermodel/HSSFSheet.java
@@ -2126,16 +2126,10 @@ public final class HSSFSheet implements Sheet {
      * it there is one.
      */
     public EscherAggregate getDrawingEscherAggregate() {
-        _book.findDrawingGroup();
-
-        // If there's now no drawing manager, then there's
-        //  no drawing escher records on the workbook
-        if (_book.getDrawingManager() == null) {
-            return null;
-        }
+        DrawingManager2 drawingManager = _book.getDrawingManager();
 
         int found = _sheet.aggregateDrawingRecords(
-                _book.getDrawingManager(), false
+            drawingManager, false
         );
         if (found == -1) {
             // Workbook has drawing stuff, but this sheet doesn't
@@ -2175,15 +2169,7 @@ public final class HSSFSheet implements Sheet {
         if (_patriarch != null) {
             return _patriarch;
         }
-        DrawingManager2 dm = _book.findDrawingGroup();
-        if (null == dm) {
-            if (!createIfMissing) {
-                return null;
-            } else {
-                _book.createDrawingGroup();
-                dm = _book.getDrawingManager();
-            }
-        }
+        DrawingManager2 dm = _book.getDrawingManager();
         EscherAggregate agg = (EscherAggregate) _sheet.findFirstRecordBySid(EscherAggregate.sid);
         if (null == agg) {
             int pos = _sheet.aggregateDrawingRecords(dm, false);

--- a/poi/src/test/java/org/apache/poi/hssf/model/TestDrawingAggregate.java
+++ b/poi/src/test/java/org/apache/poi/hssf/model/TestDrawingAggregate.java
@@ -380,7 +380,7 @@ class TestDrawingAggregate {
 
             // aggregate drawing records.
             // The subrange [19, 388] is expected to be replaced with a EscherAggregate object
-            DrawingManager2 drawingManager = iworkbook.findDrawingGroup();
+            DrawingManager2 drawingManager = iworkbook.getDrawingManager();
             int loc = isheet.aggregateDrawingRecords(drawingManager, false);
             EscherAggregate agg = (EscherAggregate) records.get(loc);
 
@@ -444,7 +444,7 @@ class TestDrawingAggregate {
 
             // aggregate drawing records.
             // The subrange [19, 38] is expected to be replaced with a EscherAggregate object
-            DrawingManager2 drawingManager = iworkbook.findDrawingGroup();
+            DrawingManager2 drawingManager = iworkbook.getDrawingManager();
             int loc = isheet.aggregateDrawingRecords(drawingManager, false);
             EscherAggregate agg = (EscherAggregate) records.get(loc);
 
@@ -525,7 +525,7 @@ class TestDrawingAggregate {
 
             // aggregate drawing records.
             // The subrange [19, 38] is expected to be replaced with a EscherAggregate object
-            DrawingManager2 drawingManager = iworkbook.findDrawingGroup();
+            DrawingManager2 drawingManager = iworkbook.getDrawingManager();
             int loc = isheet.aggregateDrawingRecords(drawingManager, false);
             EscherAggregate agg = (EscherAggregate) records.get(loc);
 
@@ -581,7 +581,7 @@ class TestDrawingAggregate {
 
             // aggregate drawing records.
             // The subrange [19, 299] is expected to be replaced with a EscherAggregate object
-            DrawingManager2 drawingManager = iworkbook.findDrawingGroup();
+            DrawingManager2 drawingManager = iworkbook.getDrawingManager();
             int loc = isheet.aggregateDrawingRecords(drawingManager, false);
             EscherAggregate agg = (EscherAggregate) records.get(loc);
 
@@ -721,7 +721,7 @@ class TestDrawingAggregate {
         int[] actualSids = dgRecords.stream().mapToInt(Record::getSid).toArray();
         assertArrayEquals(expectedSids, actualSids, "unexpected record.sid");
 
-        DrawingManager2 drawingManager = new DrawingManager2(new EscherDggRecord());
+        DrawingManager2 drawingManager = new HSSFWorkbook().getWorkbook().getDrawingManager();
 
         // create a dummy sheet consisting of our test data
         InternalSheet sheet = InternalSheet.createSheet();
@@ -887,7 +887,7 @@ class TestDrawingAggregate {
         int[] actualSids = dgRecords.stream().mapToInt(Record::getSid).toArray();
         assertArrayEquals(expectedSids, actualSids, "unexpected record.sid");
 
-        DrawingManager2 drawingManager = new DrawingManager2(new EscherDggRecord());
+        DrawingManager2 drawingManager = new HSSFWorkbook().getWorkbook().getDrawingManager();
 
         // create a dummy sheet consisting of our test data
         InternalSheet sheet = InternalSheet.createSheet();

--- a/poi/src/test/java/org/apache/poi/hssf/model/TestSheet.java
+++ b/poi/src/test/java/org/apache/poi/hssf/model/TestSheet.java
@@ -731,7 +731,7 @@ final class TestSheet {
 
         List<RecordBase> sheetRecords = sheet.getRecords();
 
-        DrawingManager2 drawingManager = new DrawingManager2(new EscherDggRecord() );
+        DrawingManager2 drawingManager = new HSSFWorkbook().getWorkbook().getDrawingManager();
         sheet.aggregateDrawingRecords(drawingManager, false);
 
         assertEquals(4, sheetRecords.size());

--- a/poi/src/test/java/org/apache/poi/hssf/usermodel/HSSFTestHelper.java
+++ b/poi/src/test/java/org/apache/poi/hssf/usermodel/HSSFTestHelper.java
@@ -18,7 +18,6 @@
 package org.apache.poi.hssf.usermodel;
 
 import org.apache.poi.ddf.*;
-import org.apache.poi.hssf.model.DrawingManager2;
 import org.apache.poi.hssf.model.InternalSheet;
 import org.apache.poi.hssf.model.InternalWorkbook;
 import org.apache.poi.hssf.record.EscherAggregate;
@@ -32,28 +31,6 @@ import org.apache.poi.hssf.record.TextObjectRecord;
  */
 public class HSSFTestHelper {
 
-    public static class MockDrawingManager extends DrawingManager2 {
-
-        public MockDrawingManager (){
-            super(null);
-        }
-
-        @Override
-        public int allocateShapeId(EscherDgRecord dg) {
-            return 1025;
-        }
-
-        @Override
-        public EscherDgRecord createDgRecord()
-        {
-            EscherDgRecord dg = new EscherDgRecord();
-            dg.setRecordId( EscherDgRecord.RECORD_ID );
-            dg.setOptions( (short) (16) );
-            dg.setNumShapes( 1 );
-            dg.setLastMSOSPID( 1024 );
-            return dg;
-        }
-    }
     /**
      * Lets non UserModel tests at the low level Workbook
      */

--- a/poi/src/test/java/org/apache/poi/hssf/usermodel/TestHSSFSheet.java
+++ b/poi/src/test/java/org/apache/poi/hssf/usermodel/TestHSSFSheet.java
@@ -810,7 +810,7 @@ final class TestHSSFSheet extends BaseTestSheet {
             assertEquals(maxDrawingGroupId1 + 1, dm1.getDgg().getMaxDrawingGroupId());
 
             try (HSSFWorkbook wb2 = writeOutAndReadBack(wb1)) {
-                DrawingManager2 dm2 = wb1.getWorkbook().getDrawingManager();
+                DrawingManager2 dm2 = wb2.getWorkbook().getDrawingManager();
                 assertEquals(maxDrawingGroupId1 + 1, dm2.getDgg().getMaxDrawingGroupId());
 
                 HSSFSheet sheet2 = wb2.getSheetAt(1);

--- a/poi/src/test/java/org/apache/poi/hssf/usermodel/TestHSSFSheet.java
+++ b/poi/src/test/java/org/apache/poi/hssf/usermodel/TestHSSFSheet.java
@@ -802,7 +802,7 @@ final class TestHSSFSheet extends BaseTestSheet {
         try (HSSFWorkbook wb1 = HSSFTestDataSamples.openSampleWorkbook("45720.xls")) {
             HSSFSheet sheet1 = wb1.getSheetAt(0);
 
-            DrawingManager2 dm1 = wb1.getWorkbook().findDrawingGroup();
+            DrawingManager2 dm1 = wb1.getWorkbook().getDrawingManager();
             int maxDrawingGroupId1 = dm1.getDgg().getMaxDrawingGroupId();
             wb1.cloneSheet(0);
 
@@ -810,7 +810,7 @@ final class TestHSSFSheet extends BaseTestSheet {
             assertEquals(maxDrawingGroupId1 + 1, dm1.getDgg().getMaxDrawingGroupId());
 
             try (HSSFWorkbook wb2 = writeOutAndReadBack(wb1)) {
-                DrawingManager2 dm2 = wb2.getWorkbook().findDrawingGroup();
+                DrawingManager2 dm2 = wb1.getWorkbook().getDrawingManager();
                 assertEquals(maxDrawingGroupId1 + 1, dm2.getDgg().getMaxDrawingGroupId());
 
                 HSSFSheet sheet2 = wb2.getSheetAt(1);

--- a/poi/src/test/java/org/apache/poi/hssf/usermodel/TestHSSFWorkbook.java
+++ b/poi/src/test/java/org/apache/poi/hssf/usermodel/TestHSSFWorkbook.java
@@ -761,7 +761,7 @@ public final class TestHSSFWorkbook extends BaseTestWorkbook {
     void clonePictures() throws IOException {
         HSSFWorkbook wb = openSampleWorkbook("SimpleWithImages.xls");
         InternalWorkbook iwb = wb.getWorkbook();
-        iwb.findDrawingGroup();
+        iwb.getDrawingManager();
 
         for(int pictureIndex=1; pictureIndex <= 4; pictureIndex++){
             EscherBSERecord bse = iwb.getBSERecord(pictureIndex);


### PR DESCRIPTION
 - [Add the ability to modify images in HSSF documents](https://github.com/pkware/poi/commit/8af8e8c78be6e5725958c77c51fb02d1a89c77e0)
 - [Add Path support for ZipPackage](https://github.com/pkware/poi/commit/e6204fa0b6c01f7c8d0455aabc7200bcb81a27d8)
 - I encountered an error building locally, relating to HTML5. Changing the `poi-ooxml/build.gradle` to match [this one](https://github.com/pkware/poi/blob/trunk/build.gradle#L221), which then [fixed the build errors](https://github.com/pkware/poi/commit/ee9c5e265a4110f9d2f4cf556d3574c59f29e464). The empty javadoc was also causing a problem.