### PR TITLE
Draft commit for reducing read IOPS in temporary package parts.

### DIFF
--- a/poi-ooxml/src/main/java/org/apache/poi/openxml4j/opc/internal/BufferedEncryptedTempFilePackagePart.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/openxml4j/opc/internal/BufferedEncryptedTempFilePackagePart.java
@@ -1,0 +1,157 @@
+/* ====================================================================
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+==================================================================== */
+
+package org.apache.poi.openxml4j.opc.internal;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.poi.openxml4j.exceptions.InvalidFormatException;
+import org.apache.poi.openxml4j.exceptions.OpenXML4JException;
+import org.apache.poi.openxml4j.opc.OPCPackage;
+import org.apache.poi.openxml4j.opc.PackagePart;
+import org.apache.poi.openxml4j.opc.PackagePartName;
+import org.apache.poi.openxml4j.opc.internal.marshallers.ZipPartMarshaller;
+import org.apache.poi.poifs.crypt.temp.EncryptedTempData;
+import org.apache.poi.util.Beta;
+import org.apache.poi.util.IOUtils;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+/**
+ * (Experimental) Buffered Encrypted Temp File version of a package part.
+ *
+ * @since POI 5.2.4
+ */
+@Beta
+public final class BufferedEncryptedTempFilePackagePart extends PackagePart {
+    private static int fileBufferSize = 1024 * 1024; // 1 MB
+    private static final Logger LOG = LogManager.getLogger(BufferedEncryptedTempFilePackagePart.class);
+
+    /**
+     * Storage for the part data.
+     */
+    private EncryptedTempData tempFile;
+
+    /**
+     * Constructor.
+     *
+     * @param pack
+     *            The owner package.
+     * @param partName
+     *            The part name.
+     * @param contentType
+     *            The content type.
+     * @throws InvalidFormatException
+     *             If the specified URI is not OPC compliant.
+     * @throws IOException
+     *             If temp file cannot be created.
+     */
+    public BufferedEncryptedTempFilePackagePart(OPCPackage pack, PackagePartName partName,
+                                                String contentType) throws InvalidFormatException, IOException {
+        this(pack, partName, contentType, true);
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param pack
+     *            The owner package.
+     * @param partName
+     *            The part name.
+     * @param contentType
+     *            The content type.
+     * @param loadRelationships
+     *            Specify if the relationships will be loaded.
+     * @throws InvalidFormatException
+     *             If the specified URI is not OPC compliant.
+     * @throws IOException
+     *             If temp file cannot be created.
+     */
+    public BufferedEncryptedTempFilePackagePart(OPCPackage pack, PackagePartName partName,
+                                                String contentType, boolean loadRelationships)
+            throws InvalidFormatException, IOException {
+        super(pack, partName, new ContentType(contentType), loadRelationships);
+        tempFile = new EncryptedTempData();
+    }
+
+    /**
+     * Allows configuration of read/write buffer sizes of temp file package parts
+     *
+     * @param bufferSize
+     *              Size of the buffer used for input/output streams.
+     */
+    public static void setBufferSize(int bufferSize) {
+        fileBufferSize = bufferSize;
+    }
+
+    @Override
+    protected InputStream getInputStreamImpl() throws IOException {
+        return new BufferedInputStream(tempFile.getInputStream(), fileBufferSize);
+    }
+
+    @Override
+    protected OutputStream getOutputStreamImpl() throws IOException {
+        return new BufferedOutputStream(tempFile.getOutputStream(), fileBufferSize);
+    }
+
+    @Override
+    public long getSize() {
+        return tempFile.getByteCount();
+    }
+
+    @Override
+    public void clear() {
+        try(OutputStream os = getOutputStreamImpl()) {
+            os.write(new byte[0]);
+        } catch (IOException e) {
+            LOG.atWarn().log("Failed to clear data in temp file", e);
+        }
+    }
+
+    @Override
+    public boolean save(OutputStream os) throws OpenXML4JException {
+        return new ZipPartMarshaller().marshall(this, os);
+    }
+
+    @Override
+    public boolean load(InputStream is) throws InvalidFormatException {
+       try (OutputStream os = getOutputStreamImpl()) {
+            IOUtils.copy(is, os);
+       } catch(IOException e) {
+            throw new InvalidFormatException(e.getMessage(), e);
+       }
+
+       // All done
+       return true;
+    }
+
+    @Override
+    public void close() {
+        tempFile.dispose();
+    }
+
+    @Override
+    public void flush() {
+        // Do nothing
+    }
+}

--- a/poi-ooxml/src/main/java/org/apache/poi/openxml4j/opc/internal/BufferedTempFilePackagePart.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/openxml4j/opc/internal/BufferedTempFilePackagePart.java
@@ -1,0 +1,160 @@
+/* ====================================================================
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+==================================================================== */
+
+package org.apache.poi.openxml4j.opc.internal;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.poi.openxml4j.exceptions.InvalidFormatException;
+import org.apache.poi.openxml4j.exceptions.OpenXML4JException;
+import org.apache.poi.openxml4j.opc.OPCPackage;
+import org.apache.poi.openxml4j.opc.PackagePart;
+import org.apache.poi.openxml4j.opc.PackagePartName;
+import org.apache.poi.openxml4j.opc.internal.marshallers.ZipPartMarshaller;
+import org.apache.poi.util.Beta;
+import org.apache.poi.util.IOUtils;
+import org.apache.poi.util.TempFile;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+/**
+ * (Experimental) Buffered Temp File version of a package part.
+ *
+ * @since POI 5.4.2
+ */
+@Beta
+public final class BufferedTempFilePackagePart extends PackagePart {
+    private static int fileBufferSize = 1024 * 1024; // 1 MB
+    private static final Logger LOG = LogManager.getLogger(BufferedTempFilePackagePart.class);
+
+    /**
+     * Storage for the part data.
+     */
+    private File tempFile;
+
+    /**
+     * Constructor.
+     *
+     * @param pack
+     *            The owner package.
+     * @param partName
+     *            The part name.
+     * @param contentType
+     *            The content type.
+     * @throws InvalidFormatException
+     *             If the specified URI is not OPC compliant.
+     * @throws IOException
+     *             If temp file cannot be created.
+     */
+    public BufferedTempFilePackagePart(OPCPackage pack, PackagePartName partName,
+                                       String contentType) throws InvalidFormatException, IOException {
+        this(pack, partName, contentType, true);
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param pack
+     *            The owner package.
+     * @param partName
+     *            The part name.
+     * @param contentType
+     *            The content type.
+     * @param loadRelationships
+     *            Specify if the relationships will be loaded.
+     * @throws InvalidFormatException
+     *             If the specified URI is not OPC compliant.
+     * @throws IOException
+     *             If temp file cannot be created.
+     */
+    public BufferedTempFilePackagePart(OPCPackage pack, PackagePartName partName,
+                                       String contentType, boolean loadRelationships)
+            throws InvalidFormatException, IOException {
+        super(pack, partName, new ContentType(contentType), loadRelationships);
+        tempFile = TempFile.createTempFile("poi-package-part", ".tmp");
+    }
+
+    /**
+     * Allows configuration of read/write buffer sizes of temp file package parts
+     *
+     * @param bufferSize
+     *              Size of the buffer used for input/output streams.
+     */
+    public static void setBufferSize(int bufferSize) {
+        fileBufferSize = bufferSize;
+    }
+
+    @Override
+    protected InputStream getInputStreamImpl() throws IOException {
+        return new BufferedInputStream(new FileInputStream(tempFile), fileBufferSize);
+    }
+
+    @Override
+    protected OutputStream getOutputStreamImpl() throws IOException {
+        return new BufferedOutputStream(new FileOutputStream(tempFile), fileBufferSize);
+    }
+
+    @Override
+    public long getSize() {
+        return tempFile.length();
+    }
+
+    @Override
+    public void clear() {
+        try(OutputStream os = getOutputStreamImpl()) {
+            os.write(new byte[0]);
+        } catch (IOException e) {
+            LOG.atWarn().log("Failed to clear data in temp file", e);
+        }
+    }
+
+    @Override
+    public boolean save(OutputStream os) throws OpenXML4JException {
+        return new ZipPartMarshaller().marshall(this, os);
+    }
+
+    @Override
+    public boolean load(InputStream is) throws InvalidFormatException {
+       try (OutputStream os = getOutputStreamImpl()) {
+            IOUtils.copy(is, os);
+       } catch(IOException e) {
+            throw new InvalidFormatException(e.getMessage(), e);
+       }
+
+       // All done
+       return true;
+    }
+
+    @Override
+    public void close() {
+        if (!tempFile.delete()) {
+            LOG.atInfo().log("Failed to delete temp file; may already have been closed and deleted");
+        }
+    }
+
+    @Override
+    public void flush() {
+        // Do nothing
+    }
+}

--- a/poi-ooxml/src/test/java/org/apache/poi/openxml4j/opc/TestBufferedEncryptedTempFilePackagePart.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/openxml4j/opc/TestBufferedEncryptedTempFilePackagePart.java
@@ -1,0 +1,53 @@
+/* ====================================================================
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+==================================================================== */
+
+package org.apache.poi.openxml4j.opc;
+
+import org.apache.poi.openxml4j.OpenXML4JTestDataSamples;
+import org.apache.poi.openxml4j.opc.internal.BufferedEncryptedTempFilePackagePart;
+import org.apache.poi.openxml4j.opc.internal.EncryptedTempFilePackagePart;
+import org.apache.poi.util.IOUtils;
+import org.junit.jupiter.api.Test;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class TestBufferedEncryptedTempFilePackagePart {
+    @Test
+    void testRoundTrip() throws Exception {
+        String text = UUID.randomUUID().toString();
+        byte[] bytes = text.getBytes(StandardCharsets.UTF_8);
+        String filepath =  OpenXML4JTestDataSamples.getSampleFileName("sample.docx");
+
+        try (OPCPackage p = OPCPackage.open(filepath, PackageAccess.READ)) {
+            PackagePartName name = new PackagePartName("/test.txt", true);
+            BufferedEncryptedTempFilePackagePart.setBufferSize(8 * 1024);
+            BufferedEncryptedTempFilePackagePart part = new BufferedEncryptedTempFilePackagePart(p, name, "text/plain");
+            try (OutputStream os = part.getOutputStream()) {
+                os.write(bytes);
+            }
+            assertEquals(bytes.length, part.getSize());
+            try (InputStream is = part.getInputStream()) {
+                assertEquals(text, new String(IOUtils.toByteArray(is), StandardCharsets.UTF_8));
+            }
+        }
+    }
+}

--- a/poi-ooxml/src/test/java/org/apache/poi/openxml4j/opc/TestBufferedTempFilePackagePart.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/openxml4j/opc/TestBufferedTempFilePackagePart.java
@@ -1,0 +1,37 @@
+package org.apache.poi.openxml4j.opc;
+
+import org.apache.poi.openxml4j.OpenXML4JTestDataSamples;
+import org.apache.poi.openxml4j.opc.internal.BufferedEncryptedTempFilePackagePart;
+import org.apache.poi.openxml4j.opc.internal.BufferedTempFilePackagePart;
+import org.apache.poi.openxml4j.opc.internal.TempFilePackagePart;
+import org.apache.poi.util.IOUtils;
+import org.junit.jupiter.api.Test;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class TestBufferedTempFilePackagePart {
+    @Test
+    void testRoundTrip() throws Exception {
+        String text = UUID.randomUUID().toString();
+        byte[] bytes = text.getBytes(StandardCharsets.UTF_8);
+        String filepath =  OpenXML4JTestDataSamples.getSampleFileName("sample.docx");
+
+        try (OPCPackage p = OPCPackage.open(filepath, PackageAccess.READ)) {
+            PackagePartName name = new PackagePartName("/test.txt", true);
+            BufferedTempFilePackagePart.setBufferSize(8 * 1024);
+            BufferedTempFilePackagePart part = new BufferedTempFilePackagePart(p, name, "text/plain");
+            try (OutputStream os = part.getOutputStream()) {
+                os.write(bytes);
+            }
+            assertEquals(bytes.length, part.getSize());
+            try (InputStream is = part.getInputStream()) {
+                assertEquals(text, new String(IOUtils.toByteArray(is), StandardCharsets.UTF_8));
+            }
+        }
+    }
+}

--- a/poi-ooxml/src/test/java/org/apache/poi/xssf/usermodel/TestXSSFWorkbook.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/xssf/usermodel/TestXSSFWorkbook.java
@@ -1243,9 +1243,11 @@ public final class TestXSSFWorkbook extends BaseTestXWorkbook {
         try(UnsynchronizedByteArrayOutputStream bos = new UnsynchronizedByteArrayOutputStream()) {
             assertFalse(ZipPackage.useTempFilePackageParts(), "useTempFilePackageParts defaults to false?");
             assertFalse(ZipPackage.encryptTempFilePackageParts(), "encryptTempFilePackageParts defaults to false?");
+            assertFalse(ZipPackage.bufferTempFilePackageParts(), "bufferTempFilePackageParts defaults to false?");
             ZipPackage.setUseTempFilePackageParts(true);
             assertTrue(ZipPackage.useTempFilePackageParts(), "useTempFilePackageParts was modified?");
             assertFalse(ZipPackage.encryptTempFilePackageParts(), "encryptTempFilePackageParts was not modified?");
+            assertFalse(ZipPackage.bufferTempFilePackageParts(), "bufferTempFilePackageParts was not modified?");
             try (XSSFWorkbook workbook = new XSSFWorkbook()) {
                 XSSFSheet sheet = workbook.createSheet("sheet1");
                 XSSFRow row = sheet.createRow(0);
@@ -1267,10 +1269,12 @@ public final class TestXSSFWorkbook extends BaseTestXWorkbook {
         try(UnsynchronizedByteArrayOutputStream bos = new UnsynchronizedByteArrayOutputStream()) {
             assertFalse(ZipPackage.useTempFilePackageParts(), "useTempFilePackageParts defaults to false?");
             assertFalse(ZipPackage.encryptTempFilePackageParts(), "encryptTempFilePackageParts defaults to false?");
+            assertFalse(ZipPackage.bufferTempFilePackageParts(), "bufferTempFilePackageParts defaults to false?");
             ZipPackage.setUseTempFilePackageParts(true);
             ZipPackage.setEncryptTempFilePackageParts(true);
             assertTrue(ZipPackage.useTempFilePackageParts(), "useTempFilePackageParts was modified?");
             assertTrue(ZipPackage.encryptTempFilePackageParts(), "encryptTempFilePackageParts was modified?");
+            assertFalse(ZipPackage.bufferTempFilePackageParts(), "bufferTempFilePackageParts was not modified?");
             try (XSSFWorkbook workbook = new XSSFWorkbook()) {
                 XSSFSheet sheet = workbook.createSheet("sheet1");
                 XSSFRow row = sheet.createRow(0);
@@ -1284,6 +1288,64 @@ public final class TestXSSFWorkbook extends BaseTestXWorkbook {
             } finally {
                 ZipPackage.setUseTempFilePackageParts(false);
                 ZipPackage.setEncryptTempFilePackageParts(false);
+            }
+        }
+    }
+
+    @Test
+    void testNewWorkbookWithBufferedEncryptedTempFilePackageParts() throws Exception {
+        try(UnsynchronizedByteArrayOutputStream bos = new UnsynchronizedByteArrayOutputStream()) {
+            assertFalse(ZipPackage.useTempFilePackageParts(), "useTempFilePackageParts defaults to false?");
+            assertFalse(ZipPackage.encryptTempFilePackageParts(), "encryptTempFilePackageParts defaults to false?");
+            assertFalse(ZipPackage.bufferTempFilePackageParts(), "bufferTempFilePackageParts defaults to false?");
+            ZipPackage.setUseTempFilePackageParts(true);
+            ZipPackage.setEncryptTempFilePackageParts(true);
+            ZipPackage.setBufferTempFilePackageParts(true);
+            assertTrue(ZipPackage.useTempFilePackageParts(), "useTempFilePackageParts was modified?");
+            assertTrue(ZipPackage.encryptTempFilePackageParts(), "encryptTempFilePackageParts was modified?");
+            assertTrue(ZipPackage.bufferTempFilePackageParts(), "bufferTempFilePackageParts was modified?");
+            try (XSSFWorkbook workbook = new XSSFWorkbook()) {
+                XSSFSheet sheet = workbook.createSheet("sheet1");
+                XSSFRow row = sheet.createRow(0);
+                XSSFCell cell0 = row.createCell(0);
+                cell0.setCellValue("");
+                XSSFCell cell1 = row.createCell(1);
+                cell1.setCellErrorValue(FormulaError.DIV0);
+                XSSFCell cell2 = row.createCell(2);
+                cell2.setCellErrorValue(FormulaError.FUNCTION_NOT_IMPLEMENTED);
+                workbook.write(bos);
+            } finally {
+                ZipPackage.setUseTempFilePackageParts(false);
+                ZipPackage.setEncryptTempFilePackageParts(false);
+                ZipPackage.setBufferTempFilePackageParts(false);
+            }
+        }
+    }
+
+    @Test
+    void testNewWorkbookWithBufferedTempFilePackageParts() throws Exception {
+        try(UnsynchronizedByteArrayOutputStream bos = new UnsynchronizedByteArrayOutputStream()) {
+            assertFalse(ZipPackage.useTempFilePackageParts(), "useTempFilePackageParts defaults to false?");
+            assertFalse(ZipPackage.encryptTempFilePackageParts(), "encryptTempFilePackageParts defaults to false?");
+            assertFalse(ZipPackage.bufferTempFilePackageParts(), "bufferTempFilePackageParts defaults to false?");
+            ZipPackage.setUseTempFilePackageParts(true);
+            ZipPackage.setBufferTempFilePackageParts(true);
+            assertTrue(ZipPackage.useTempFilePackageParts(), "useTempFilePackageParts was modified?");
+            assertFalse(ZipPackage.encryptTempFilePackageParts(), "encryptTempFilePackageParts defaults to false?");
+            assertTrue(ZipPackage.bufferTempFilePackageParts(), "bufferTempFilePackageParts was modified?");
+            try (XSSFWorkbook workbook = new XSSFWorkbook()) {
+                XSSFSheet sheet = workbook.createSheet("sheet1");
+                XSSFRow row = sheet.createRow(0);
+                XSSFCell cell0 = row.createCell(0);
+                cell0.setCellValue("");
+                XSSFCell cell1 = row.createCell(1);
+                cell1.setCellErrorValue(FormulaError.DIV0);
+                XSSFCell cell2 = row.createCell(2);
+                cell2.setCellErrorValue(FormulaError.FUNCTION_NOT_IMPLEMENTED);
+                workbook.write(bos);
+            } finally {
+                ZipPackage.setUseTempFilePackageParts(false);
+                ZipPackage.setBufferTempFilePackageParts(false);
             }
         }
     }


### PR DESCRIPTION
Don't give any priority to reviewing this. I just wanted this to exist and have you aware of the idea of something I've tested with and confirmed helps us. All we need to do in the Unpacker is call `ZipPackage.setBufferTempFilePackageParts(true)` to reap the benefits.